### PR TITLE
Fix: Emission node labels display correct values immediately and update on mode switch

### DIFF
--- a/src/sections/Section16.js
+++ b/src/sections/Section16.js
@@ -692,7 +692,7 @@ window.TEUI.SectionModules.sect16 = (function () {
         .attr("x", (d) => (d.x0 < this.width / 2 ? d.x1 + 6 : d.x0 - 6))
         .attr("y", (d) => (d.y1 + d.y0) / 2)
         .attr("dy", "0.35em")
-        .text((d) => d.name)
+        .text((d) => this.formatNodeLabel(d))
         .style("opacity", 0); // Start invisible
 
       // Merge new and existing labels for updates
@@ -700,7 +700,8 @@ window.TEUI.SectionModules.sect16 = (function () {
         .merge(textEnter)
         .attr("text-anchor", (d) => (d.x0 < this.width / 2 ? "start" : "end"))
         .attr("x", (d) => (d.x0 < this.width / 2 ? d.x1 + 6 : d.x0 - 6))
-        .attr("y", (d) => (d.y1 + d.y0) / 2);
+        .attr("y", (d) => (d.y1 + d.y0) / 2)
+        .text((d) => this.formatNodeLabel(d)); // Update text on refresh
 
       // EXACT SANKEY3035ORIGINAL ANIMATION PATTERN FOR LABELS
       if (isInitialLoad) {

--- a/src/sections/Section16.js
+++ b/src/sections/Section16.js
@@ -927,11 +927,22 @@ window.TEUI.SectionModules.sect16 = (function () {
 
     formatNodeLabel(node) {
       if (node.name && node.name.toLowerCase().includes("emissions")) {
-        const totalEmissionsInGrams =
-          node.targetLinks?.reduce((sum, link) => sum + link.value, 0) || 0;
-        const kgValue = totalEmissionsInGrams / 1000;
+        let totalEmissionsKg = 0;
+
+        // Read emission values directly from StateManager (mode-aware)
+        // These values are calculated by other sections and are always available
+        if (node.name.includes("Scope 1")) {
+          // Scope 1: Gas/Oil emissions from Space Heating and DHW
+          const spaceHeatingEmissionsKg = parseFloat(getModeAwareValue("f_114") || 0);
+          const dhwEmissionsKg = parseFloat(getModeAwareValue("k_49") || 0);
+          totalEmissionsKg = spaceHeatingEmissionsKg + dhwEmissionsKg;
+        } else if (node.name.includes("Scope 2")) {
+          // Scope 2: Electricity emissions
+          totalEmissionsKg = parseFloat(getModeAwareValue("k_27") || 0);
+        }
+
         const formattedKgValue = window.TEUI.formatNumber(
-          kgValue,
+          totalEmissionsKg,
           "number-2dp-comma",
         );
         return `${node.name} (${formattedKgValue} kg CO2e/yr)`;


### PR DESCRIPTION
## Summary
Fixes emission node labels in Section 16 Sankey diagram to display correct CO2e values immediately on activation and properly update when switching between Target and Reference modes.

## Problem
Previously, emission node labels showed "0.00 kg CO2e/yr" on initial render, requiring a manual refresh to display correct values. Additionally, labels did not update when switching between Target and Reference modes.

**Issue Screenshot:**
- Link tooltips showed correct values (e.g., "6,821.62 kg CO2e/yr")
- Node labels showed "0.00 kg CO2e/yr"

## Root Causes
1. **Initial render issue**: `formatNodeLabel()` attempted to calculate values from `node.targetLinks` which is populated by D3's Sankey layout, but labels are rendered before D3 fully populates these links with emission flow data.

2. **Mode switching issue**: `renderLabels()` method did not call `formatNodeLabel()` when updating existing labels during a refresh, so labels never updated their text content when modes switched.

## Solution

### 1. Read Directly from StateManager (Commit 36bc26e)
Modified `formatNodeLabel()` to read emission values directly from StateManager fields that are already calculated by other sections:
- **k_27** → Scope 2 electricity emissions (from S06)
- **f_114** → Scope 1 space heating emissions from gas/oil (from S06)
- **k_49** → Scope 1 DHW emissions from gas/oil (from S07)

**Benefits:**
- ✅ Values are available immediately, before Sankey activation
- ✅ Mode-aware via `getModeAwareValue()` for target/reference support
- ✅ Simpler logic - no need to traverse link structures
- ✅ More reliable - single source of truth from StateManager

### 2. Update Labels on Refresh (Commit be23f8e)
Modified `renderLabels()` to call `formatNodeLabel()` in two places:
- Line 695: Changed `.text((d) => d.name)` to `.text((d) => this.formatNodeLabel(d))` for new labels
- Line 704: Added `.text((d) => this.formatNodeLabel(d))` to the textUpdate merge chain

This ensures labels update their text content on every render, properly reflecting the current mode.

## Mode-Aware Field Mapping
When switching modes, the system automatically reads from the correct StateManager fields:

| Mode | Electricity (Scope 2) | Space Heating (Scope 1) | DHW (Scope 1) |
|------|----------------------|-------------------------|---------------|
| **Target** | k_27 | f_114 | k_49 |
| **Reference** | ref_k_27 | ref_f_114 | ref_k_49 |

## Testing Completed
- ✅ Emission labels display correct values immediately on Sankey activation
- ✅ Labels update correctly when switching to Reference mode
- ✅ Labels update correctly when switching back to Target mode
- ✅ Values remain correct after multiple mode switches
- ✅ Both Scope 1 and Scope 2 emission nodes work correctly

## Files Changed
- `src/sections/Section16.js`
  - Modified `formatNodeLabel()` method to read from StateManager (lines 928-951)
  - Modified `renderLabels()` method to update label text on refresh (lines 695, 704)

## Commits
- 36bc26e: Fix: Emissions node labels read directly from StateManager
- be23f8e: Fix: Update emission labels when switching Target/Reference modes

## Related Issue
Fixes #6

---

🤖 Generated with Andy and his favourite stochastic hallucinator [Claudette Code]