### PR TITLE
Fix: Add null safety to Section12 reference value publishing

### DIFF
--- a/src/sections/Section12.js
+++ b/src/sections/Section12.js
@@ -2832,7 +2832,7 @@ window.TEUI.SectionModules.sect12 = (function () {
       Object.entries(lastReferenceResults).forEach(([fieldId, value]) => {
         window.TEUI.StateManager.setValue(
           `ref_${fieldId}`,
-          value.toString(),
+          (value ?? "").toString(),
           "calculated"
         );
       });


### PR DESCRIPTION
Prevents "Cannot read properties of null (reading 'toString')" error when reference calculation results contain null values.

- Change: value.toString() → (value ?? "").toString()
- Location: Section12.js line 2835 (reference results publishing)
- Impact: Null/undefined values now safely convert to empty strings

This defensive coding prevents console errors when field calculations return null (e.g., during initialization or data loading).

🤖 Co-Generated with [Claude Code](https://claude.com/claude-code)