### PR TITLE
Fix: Copy from Target regression - force dual-state sync

### DIFF
--- a/src/core/ReferenceToggle.js
+++ b/src/core/ReferenceToggle.js
@@ -983,8 +983,11 @@ TEUI.ReferenceToggle = (function () {
         );
 
         // Sync Pattern A sections (critical for UI updates!)
+        // ⚠️ CRITICAL: Copy operations must sync BOTH states (skipTargetSync=false, skipReferenceSync=false)
+        // This is different from Set Values which is mode-aware. Copy explicitly writes ref_* fields
+        // and needs both TargetState (unchanged) and ReferenceState (updated) to sync properly.
         if (window.TEUI?.FileHandler?.syncPatternASections) {
-          window.TEUI.FileHandler.syncPatternASections();
+          window.TEUI.FileHandler.syncPatternASections(false, false, false); // skipAreaSync, skipTargetSync, skipReferenceSync
         } else {
           console.warn(
             "[ReferenceToggle] FileHandler.syncPatternASections not available - UI may not update"
@@ -1107,8 +1110,11 @@ TEUI.ReferenceToggle = (function () {
         );
 
         // Sync Pattern A sections
+        // ⚠️ CRITICAL: Copy operations must sync BOTH states (skipTargetSync=false, skipReferenceSync=false)
+        // This is different from Set Values which is mode-aware. Copy explicitly writes ref_* fields
+        // and needs both TargetState (unchanged) and ReferenceState (updated) to sync properly.
         if (window.TEUI?.FileHandler?.syncPatternASections) {
-          window.TEUI.FileHandler.syncPatternASections();
+          window.TEUI.FileHandler.syncPatternASections(false, false, false); // skipAreaSync, skipTargetSync, skipReferenceSync
         }
       } finally {
         // QUARANTINE END - Always unmute
@@ -1195,8 +1201,11 @@ TEUI.ReferenceToggle = (function () {
         );
 
         // Sync Pattern A sections (critical for UI updates!)
+        // ⚠️ CRITICAL: Copy operations must sync BOTH states (skipTargetSync=false, skipReferenceSync=false)
+        // This is different from Set Values which is mode-aware. Copy explicitly writes ref_* fields
+        // and needs both TargetState (unchanged) and ReferenceState (updated) to sync properly.
         if (window.TEUI?.FileHandler?.syncPatternASections) {
-          window.TEUI.FileHandler.syncPatternASections();
+          window.TEUI.FileHandler.syncPatternASections(false, false, false); // skipAreaSync, skipTargetSync, skipReferenceSync
         } else {
           console.warn(
             "[ReferenceToggle] FileHandler.syncPatternASections not available - UI may not update"


### PR DESCRIPTION
Problem:
After Fix #6 (mode-aware Set Values), Copy from Target functions became inverted in Reference mode - copying Reference→Target instead of Target→Reference.

Root Cause:
Copy functions called syncPatternASections() without parameters, which now checks global UI mode. In Reference mode, it skips TargetState sync, causing the inversion.

Solution:
Explicitly pass (false, false, false) to syncPatternASections() in all three Copy functions to force BOTH states to sync:
- mirrorGeometry()
- mirrorGeometryPlusCode()
- mirrorAllInputs()

Why This Works:
Copy operations are fundamentally different from Set Values:
- Set Values: Mode-aware (sync only the active state)
- Copy: Always sync BOTH states (Target unchanged, Reference updated)

This fix ensures Copy always syncs both TargetState and ReferenceState, regardless of UI mode, preserving the Target→Reference copy direction.

Files Modified:
- src/core/ReferenceToggle.js (3 functions updated)

Testing:
Verify Copy from Target in Reference mode copies Target→Reference, not inverted. Verify Set Values still works correctly in both modes (no regression).

🤖 Co-Generated with Claude Code https://claude.com/claude-code