### PR TITLE
Fix: Add Reference mode DOM updates for S19 → S12 bidirectional sync

### DIFF
--- a/src/sections/Section12.js
+++ b/src/sections/Section12.js
@@ -3131,6 +3131,16 @@ window.TEUI.SectionModules.sect12 = (function () {
           console.log(`[S12→WOMBAT] Syncing ref_d_105 = ${newValue} from WOMBAT ref_d_198`);
           ReferenceState.setValue("d_105", newValue);
           window.TEUI.StateManager.setValue("ref_d_105", newValue, "external");
+
+          // ✅ FIX: Explicit DOM update for d_105 when in Reference mode
+          if (ModeManager.currentMode === "reference" && window.TEUI?.FieldManager) {
+            const fieldDef = window.TEUI.FieldManager.getField("d_105");
+            if (fieldDef) {
+              window.TEUI.FieldManager.updateFieldDisplay("d_105", newValue, fieldDef);
+              console.log(`[S12→WOMBAT] ✅ Refreshed d_105 DOM = ${newValue} (Reference mode)`);
+            }
+          }
+
           calculateAll();
           ModeManager.updateCalculatedDisplayValues();
         }
@@ -3143,6 +3153,16 @@ window.TEUI.SectionModules.sect12 = (function () {
           console.log(`[S12→WOMBAT] Syncing ref_d_103 = ${newValue} from WOMBAT ref_d_199`);
           ReferenceState.setValue("d_103", newValue);
           window.TEUI.StateManager.setValue("ref_d_103", newValue, "external");
+
+          // ✅ FIX: Explicit DOM update for d_103 dropdown when in Reference mode
+          if (ModeManager.currentMode === "reference") {
+            const dropdown = document.querySelector('select[data-field-id="d_103"]');
+            if (dropdown) {
+              dropdown.value = newValue;
+              console.log(`[S12→WOMBAT] ✅ Refreshed d_103 DOM = ${newValue} (Reference mode)`);
+            }
+          }
+
           calculateAll();
           ModeManager.updateCalculatedDisplayValues();
         }


### PR DESCRIPTION
Added explicit FieldManager.updateFieldDisplay() calls to Reference mode listeners for d_198 and d_199 in Section12.js to fix S19 → S12 DOM refresh issue in Reference mode.

Root cause: updateCalculatedDisplayValues() excludes d_105/d_103 as they are user input fields, not calculated fields. This is correct for normal operations but fails when d_105/d_103 receive values from S19 via bidirectional sync.

Target mode already had explicit DOM updates and worked correctly. This fix applies the same pattern to Reference mode listeners.

Changes:
- Section12.js:3135-3142: Add mode-aware DOM update for ref_d_198 → d_105
- Section12.js:3157-3164: Add mode-aware DOM update for ref_d_199 → d_103

🤖 Co-Generated with [Claude Code](https://claude.com/claude-code)