### PR TITLE
Add TGS4 Tier 2/3 adopted embodied carbon caps

### DIFF
--- a/docs/TGS4_ANALYSIS.md
+++ b/docs/TGS4_ANALYSIS.md
@@ -1,0 +1,130 @@
+# TGS Version 4 — Embodied Carbon & Energy Targets
+
+## Source Clarification
+
+From **Ryan Zizzo** (Mantle Climate), co-author of the TGS4 guidelines with Kelly Alvarez-Doran:
+
+> Kelly and I created that "Figure 1" you are referring to. The City did not adopt those values as is.
+
+The currently implemented `TYPOLOGY_CAPS` in `BuildingInfoNodes.js` are based on that Figure 1 (varying by material type: stick frame 125, mass timber 250/350, concrete 550, steel 650). **These are NOT the adopted TGS4 values.**
+
+The actual adopted values are on the TGSv4 pages:
+- Part 3: https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/mid-to-high-rise-residential-non-residential-version-4/buildings-energy-emissions-resilience/
+- Part 9: https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/low-rise-residential-version-4/buildings-energy-emissions/
+- City-Owned: https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/city-agency-corporation-division-owned-facilities-version-4/buildings-energy-emissions-resilience/
+
+**The caps do NOT vary by material type** (i.e., steel, concrete, wood all have the same cap).
+
+## Terminology (from Ryan Zizzo)
+
+> The industry uses "embodied" to represent emissions out to the atmosphere, and "storage" to represent what is actually stored / sequestered into a material. We need to get folks comfortable with these terms. Introducing additional ones like "embedded" just adds to the confusion.
+
+**Use:**
+- **"embodied"** — emissions released to atmosphere (kgCO2e/m²)
+- **"storage"** — carbon sequestered in materials
+
+**Do NOT introduce:** "embedded" or other alternative terms.
+
+## Open Question
+
+> Need to consider whether we update TGS4 and provide a second set of expected/guidance values for practitioners that have never done embodied carbon analysis before to understand some guidance boundaries or not.
+
+---
+
+## Adopted TGS4 Values (from City of Toronto pages)
+
+### Part 3: Mid-to-High-Rise Residential & Non-Residential
+
+#### Operational — GHGI (kgCO2e/m²/yr) — GHG 1.1
+
+| Building Type        | Tier 1 (Mandatory) | Tier 2 | Tier 3 | City-Owned |
+|----------------------|--------------------:|-------:|-------:|-----------:|
+| All Residential      |                  15 |     10 |      5 |          0 |
+| Commercial Office    |                  15 |      8 |      4 |          0 |
+| Commercial Retail    |                  10 |      5 |      3 |          0 |
+
+Mixed-use buildings use weighted averages.
+
+#### Operational — TEUI & TEDI (kWh/m²/yr) — GHG 1.2
+
+| Building Type                    | Tier 1 TEUI | Tier 1 TEDI | Tier 2 TEUI | Tier 2 TEDI | Tier 3 TEUI | Tier 3 TEDI |
+|----------------------------------|------------:|------------:|------------:|------------:|------------:|------------:|
+| MURB (>6 storeys)               |         135 |          50 |         100 |          30 |          75 |          15 |
+| MURB (≤6 storeys)               |         130 |          40 |         100 |          25 |          70 |          15 |
+| Commercial Office                |         130 |          30 |         100 |          22 |          65 |          15 |
+| Commercial Retail                |         120 |          40 |          90 |          25 |          70 |          15 |
+
+#### Embodied Carbon — Upfront (A1-A5) — GHG 2.1 / GHG 2.2
+
+| Category               | Tier 2 (GHG 2.1) | Tier 3 (GHG 2.2) |
+|------------------------|------------------:|------------------:|
+| Residential/Commercial |    ≤350 kgCO2e/m² |    ≤250 kgCO2e/m² |
+| Other building types   |    ≤400 kgCO2e/m² |    ≤275 kgCO2e/m² |
+
+Scope: Structure and envelope only. Caps do NOT vary by material type.
+
+### Part 9: Low-Rise Residential
+
+#### Embodied Carbon — GHG 3.1 (Tier 2)
+
+| Category        | Cap               |
+|-----------------|------------------:|
+| Low-Rise Res.   |    ≤250 kgCO2e/m² |
+
+Scope: Structural, enclosure, major finish materials. LCA stages A1-A3. BEAM or equivalent tool.
+
+### City-Owned Buildings
+
+#### Operational — GHG 1.1
+
+| Metric | Target          |
+|--------|----------------:|
+| GHGI   | 0 (net-zero)    |
+| TEDI   | ≤30 kWh/m²/yr  |
+| TEUI   | ≤100 kWh/m²/yr |
+
+Alternative compliance: 50% better than OBC SB-10 Div 3 (2017), Passive House cert, or CaGBC Zero Carbon cert.
+
+#### Embodied Carbon — GHG 2.1 / GHG 2.2
+
+Same as Part 3:
+- GHG 2.1: ≤350 / ≤400 kgCO2e/m²
+- GHG 2.2: ≤250 / ≤275 kgCO2e/m²
+
+---
+
+## Impact on Current Code
+
+### `BuildingInfoNodes.js` — `TYPOLOGY_CAPS` (line 136)
+
+Current values (from Figure 1 — NOT adopted):
+```javascript
+const TYPOLOGY_CAPS = {
+  "Pt.9 Res. Stick Frame": 125,
+  "Pt.9 Small Mass Timber": 250,
+  "Pt.3 Mass Timber": 350,
+  "Pt.3 Concrete": 550,
+  "Pt.3 Steel": 650,
+  "Pt.3 Office": 600,
+};
+```
+
+These vary by material type and do NOT match the adopted TGS4 caps.
+
+### What the adopted TGS4 caps actually are:
+
+| Scope                               | Tier 2 Cap | Tier 3 Cap |
+|--------------------------------------|------------|------------|
+| Part 9 Low-Rise Residential          | 250        | —          |
+| Part 3 Residential/Commercial        | 350        | 250        |
+| Part 3 Other                         | 400        | 275        |
+| City-Owned Residential/Commercial    | 350        | 250        |
+| City-Owned Other                     | 400        | 275        |
+
+No variation by material type (steel = concrete = wood = same cap).
+
+### Decision Needed
+
+1. **Replace `TYPOLOGY_CAPS`** with actual TGS4 adopted values (by building category + tier, NOT by material type)
+2. **Keep Figure 1 values** as optional practitioner guidance (Ryan's open question)
+3. **Terminology audit** — ensure "embodied" is used consistently, remove any "embedded" references

--- a/docs/parnas-tables/README.md
+++ b/docs/parnas-tables/README.md
@@ -47,6 +47,7 @@ parnas-tables/
 ├── format.schema.json        # JSON Schema for table format
 ├── climate/                  # S03 - Climate calculations
 ├── cooling/                  # S13 - Free cooling, active cooling days
+├── emissions/                # S02/S05 - Embodied carbon targets, TGS4 caps
 ├── energy/                   # S04/S14/S15 - Energy metrics
 ├── f280/                     # SF280 - CSA F280-12 peak loads & compliance
 ├── internal-gains/           # S09 - Occupants, plugs, lighting, equipment
@@ -147,6 +148,45 @@ The F280 calculations are implemented in `src/sections/nodes/F280ComplianceNodes
 which reuses existing computation graph inputs (envelope U×A values, climate design
 temperatures, ventilation rates, air tightness parameters) and derives peak loads
 from them.
+
+## Emissions Section (S02/S05) — Embodied Carbon
+
+The emissions section handles embodied carbon targets based on the selected carbon benchmarking standard.
+
+### TGS4 Embodied Carbon Caps
+
+The City of Toronto adopted embodied carbon caps that vary by **building category and tier**, NOT by material type. The material-specific values from "Figure 1" (created by Ryan Zizzo and Kelly Alvarez-Doran at Mantle Climate) were not adopted as-is.
+
+| File | ID | Description |
+|---|---|---|
+| `tgs4-building-category.json` | `emissions.tgs4.buildingCategory` | Maps occupancy + storeys to TGS4 category |
+| `embodied-carbon-target.json` | `building.embodiedCarbonTarget` | Embodied carbon cap by standard selection |
+
+### Category Determination
+
+The Part 9 vs Part 3 boundary for residential buildings is **3 storeys** (OBC threshold):
+
+| Occupancy | Storeys | Category |
+|---|---|---|
+| C-Residential | ≤3 | Part 9 Low-Rise Residential |
+| C-Residential | >3 | Part 3 Residential/Commercial |
+| D-Business, E-Mercantile | any | Part 3 Residential/Commercial |
+| A-Assembly, B-Institutional, F-Industrial | any | Part 3 Other |
+
+### Adopted TGS4 Caps (kgCO2e/m²)
+
+| Category | Tier 2 | Tier 3 |
+|---|---|---|
+| Part 9 Low-Rise Residential (A1-A3) | 250 | — |
+| Part 3 Residential/Commercial (A1-A5) | 350 | 250 |
+| Part 3 Other (A1-A5) | 400 | 275 |
+
+### Terminology
+
+Per Ryan Zizzo (Mantle Climate):
+- **"embodied"** — emissions released to atmosphere (kgCO2e/m²)
+- **"storage"** — carbon sequestered in materials
+- Do NOT use "embedded"
 
 ## Code Generation
 

--- a/docs/parnas-tables/emissions/embodied-carbon-target.json
+++ b/docs/parnas-tables/emissions/embodied-carbon-target.json
@@ -1,0 +1,287 @@
+{
+  "id": "building.embodiedCarbonTarget",
+  "legacyId": "d_16",
+  "label": "Embodied Carbon Target",
+  "section": "S02",
+  "classification": "C",
+  "_meta": {
+    "description": "Embodied carbon cap (kgCO2e/m²) determined by the selected carbon benchmarking standard. For TGS4 Tier 2/3, the cap is looked up from the adopted City of Toronto values by building category (occupancy + storeys). For the legacy TGS4 'Typical Values', the cap comes from the material-based typology. For other standards, fixed targets or user-modelled values are used.",
+    "terminology": "Use 'embodied' for emissions released to atmosphere. Use 'storage' for carbon sequestered in materials. Do not use 'embedded'. — Ryan Zizzo, Mantle Climate"
+  },
+  "signature": {
+    "inputs": [
+      {
+        "name": "building.carbonStandard",
+        "type": "string",
+        "description": "Carbon benchmarking standard selection (d_15)"
+      },
+      {
+        "name": "building.typologyEmbodiedCarbon",
+        "type": "number",
+        "unit": "kgCO2e/m²",
+        "description": "Material-based typology cap from TYPOLOGY_CAPS lookup (i_39)"
+      },
+      {
+        "name": "building.userModelledEmbodiedCarbon",
+        "type": "number",
+        "unit": "kgCO2e/m²",
+        "description": "User-entered modelled embodied carbon value (i_41)"
+      },
+      {
+        "name": "building.majorOccupancy",
+        "type": "string",
+        "description": "OBC Major Occupancy classification (d_12) — used for TGS4 Tier 2/3 only"
+      },
+      {
+        "name": "building.numStoreys",
+        "type": "number",
+        "description": "Number of storeys (d_16_storeys) — used for TGS4 Tier 2/3 only"
+      }
+    ],
+    "output": {
+      "type": "number | string",
+      "unit": "kgCO2e/m²",
+      "note": "Returns 'N/A' when standard is 'Not Reported' or when no cap exists (e.g., Part 9 + Tier 3)"
+    }
+  },
+  "domain": {
+    "preconditions": [
+      {
+        "condition": "building.carbonStandard is a valid dropdown value",
+        "description": "Must be one of the supported standards"
+      }
+    ],
+    "invariants": [
+      {
+        "condition": "When output is numeric, output > 0",
+        "description": "Embodied carbon caps are always positive"
+      },
+      {
+        "condition": "TGS4 Tier 2/3 caps do NOT vary by material type",
+        "description": "The City of Toronto did not adopt the material-specific Figure 1 values"
+      }
+    ]
+  },
+  "behavior": [
+    {
+      "condition": "standard == 'Not Reported'",
+      "output": "N/A"
+    },
+    {
+      "condition": "standard == 'TGS4 Tier 2' AND category == 'Part 9 Low-Rise Residential'",
+      "output": "250",
+      "note": "LCA scope A1-A3. Structure and enclosure."
+    },
+    {
+      "condition": "standard == 'TGS4 Tier 2' AND category == 'Part 3 Residential/Commercial'",
+      "output": "350",
+      "note": "LCA scope A1-A5. Structure and envelope."
+    },
+    {
+      "condition": "standard == 'TGS4 Tier 2' AND category == 'Part 3 Other'",
+      "output": "400",
+      "note": "LCA scope A1-A5. Structure and envelope."
+    },
+    {
+      "condition": "standard == 'TGS4 Tier 3' AND category == 'Part 9 Low-Rise Residential'",
+      "output": "N/A",
+      "note": "Part 9 has no Tier 3 target in TGS4."
+    },
+    {
+      "condition": "standard == 'TGS4 Tier 3' AND category == 'Part 3 Residential/Commercial'",
+      "output": "250",
+      "note": "LCA scope A1-A5. Structure and envelope."
+    },
+    {
+      "condition": "standard == 'TGS4 Tier 3' AND category == 'Part 3 Other'",
+      "output": "275",
+      "note": "LCA scope A1-A5. Structure and envelope."
+    },
+    {
+      "condition": "standard == 'TGS4' (legacy 'Typical Values')",
+      "output": "building.typologyEmbodiedCarbon",
+      "note": "Backward compat: uses material-based TYPOLOGY_CAPS (Figure 1 values, not adopted by City)"
+    },
+    {
+      "condition": "standard in CARBON_TARGETS (LEED, Passive House, CaGBC, etc.)",
+      "output": "CARBON_TARGETS[standard]",
+      "note": "Fixed caps: LEED BD+C v4.1 = 500, LEED 40% = 300, ZCB = 250, PH = 200, CaGBC = 175"
+    },
+    {
+      "condition": "standard == 'Self Reported'",
+      "output": "building.userModelledEmbodiedCarbon",
+      "note": "User-entered value from i_41 field"
+    }
+  ],
+  "edgeCases": [
+    {
+      "condition": "TGS4 Tier 3 selected for Part 9 building",
+      "handling": "Return 'N/A'",
+      "rationale": "Part 9 Low-Rise Residential has no Tier 3 embodied carbon target in TGS4"
+    },
+    {
+      "condition": "Bare 'TGS4' from old saved state / CSV import",
+      "handling": "Falls through to legacy typology path (backward compat)",
+      "rationale": "Old files saved with 'TGS4' still work via material-based TYPOLOGY_CAPS"
+    },
+    {
+      "condition": "Occupancy changes while TGS4 Tier selected",
+      "handling": "Recompute via dependency on building.majorOccupancy",
+      "rationale": "Category changes when occupancy changes (e.g., residential → commercial)"
+    },
+    {
+      "condition": "Storey count changes while TGS4 Tier selected for C-Residential",
+      "handling": "Recompute via dependency on building.numStoreys",
+      "rationale": "Part 9 vs Part 3 boundary is at 3 storeys for residential"
+    }
+  ],
+  "formula": {
+    "implementation": "BuildingInfoNodes.js: building.embodiedCarbonTarget compute node",
+    "legacy": "Section02.js: calculateTargetModel(), calculateReferenceModel()",
+    "lookup_tables": {
+      "TGS4_CAPS": {
+        "Part 9 Low-Rise Residential": { "TGS4 Tier 2": 250, "TGS4 Tier 3": null },
+        "Part 3 Residential/Commercial": { "TGS4 Tier 2": 350, "TGS4 Tier 3": 250 },
+        "Part 3 Other": { "TGS4 Tier 2": 400, "TGS4 Tier 3": 275 }
+      },
+      "TYPOLOGY_CAPS (legacy Figure 1)": {
+        "Pt.9 Res. Stick Frame": 125,
+        "Pt.9 Small Mass Timber": 250,
+        "Pt.3 Mass Timber": 350,
+        "Pt.3 Concrete": 550,
+        "Pt.3 Steel": 650,
+        "Pt.3 Office": 600
+      },
+      "CARBON_TARGETS": {
+        "LEED BD+C v4.1": 500,
+        "LEED BD+C v4.1 (40%)": 300,
+        "Zero Carbon Building": 250,
+        "Passive House": 200,
+        "CaGBC Zero Carbon": 175,
+        "Self Reported": null
+      }
+    }
+  },
+  "tests": [
+    {
+      "name": "TGS4 Tier 2 — Part 9 low-rise residential (2 storeys)",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 2",
+        "building.majorOccupancy": "C-Residential",
+        "building.numStoreys": 2
+      },
+      "expected": 250
+    },
+    {
+      "name": "TGS4 Tier 2 — Part 9 low-rise residential (3 storey boundary)",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 2",
+        "building.majorOccupancy": "C-Residential",
+        "building.numStoreys": 3
+      },
+      "expected": 250
+    },
+    {
+      "name": "TGS4 Tier 2 — Part 3 mid-rise residential (4 storey boundary)",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 2",
+        "building.majorOccupancy": "C-Residential",
+        "building.numStoreys": 4
+      },
+      "expected": 350
+    },
+    {
+      "name": "TGS4 Tier 2 — Part 3 commercial office",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 2",
+        "building.majorOccupancy": "D-Business & Personal Services",
+        "building.numStoreys": 5
+      },
+      "expected": 350
+    },
+    {
+      "name": "TGS4 Tier 2 — Part 3 other (assembly)",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 2",
+        "building.majorOccupancy": "A-Assembly",
+        "building.numStoreys": 2
+      },
+      "expected": 400
+    },
+    {
+      "name": "TGS4 Tier 3 — Part 9 (no target exists)",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 3",
+        "building.majorOccupancy": "C-Residential",
+        "building.numStoreys": 2
+      },
+      "expected": "N/A"
+    },
+    {
+      "name": "TGS4 Tier 3 — Part 3 mid-rise residential",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 3",
+        "building.majorOccupancy": "C-Residential",
+        "building.numStoreys": 4
+      },
+      "expected": 250
+    },
+    {
+      "name": "TGS4 Tier 3 — Part 3 other (assembly)",
+      "inputs": {
+        "building.carbonStandard": "TGS4 Tier 3",
+        "building.majorOccupancy": "A-Assembly",
+        "building.numStoreys": 2
+      },
+      "expected": 275
+    },
+    {
+      "name": "TGS4 legacy 'Typical Values' — mass timber",
+      "inputs": {
+        "building.carbonStandard": "TGS4",
+        "building.typologyEmbodiedCarbon": 350
+      },
+      "expected": 350
+    },
+    {
+      "name": "Self Reported",
+      "inputs": {
+        "building.carbonStandard": "Self Reported",
+        "building.userModelledEmbodiedCarbon": 345.82
+      },
+      "expected": 345.82
+    },
+    {
+      "name": "Not Reported",
+      "inputs": {
+        "building.carbonStandard": "Not Reported"
+      },
+      "expected": "N/A"
+    },
+    {
+      "name": "LEED BD+C v4.1",
+      "inputs": {
+        "building.carbonStandard": "LEED BD+C v4.1"
+      },
+      "expected": 500
+    }
+  ],
+  "references": [
+    {
+      "source": "City of Toronto TGS Version 4 — Part 3 Mid-to-High Rise",
+      "url": "https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/mid-to-high-rise-residential-non-residential-version-4/buildings-energy-emissions-resilience/"
+    },
+    {
+      "source": "City of Toronto TGS Version 4 — Part 9 Low-Rise Residential",
+      "url": "https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/low-rise-residential-version-4/buildings-energy-emissions/"
+    },
+    {
+      "source": "City of Toronto TGS Version 4 — City-Owned Buildings",
+      "url": "https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/city-agency-corporation-division-owned-facilities-version-4/buildings-energy-emissions-resilience/"
+    },
+    {
+      "source": "Ryan Zizzo, Mantle Climate — clarification on adopted vs Figure 1 values",
+      "note": "The caps do NOT vary by material type (ie: steel, concrete, wood)"
+    }
+  ]
+}

--- a/docs/parnas-tables/emissions/embodied-carbon-target.json
+++ b/docs/parnas-tables/emissions/embodied-carbon-target.json
@@ -103,9 +103,49 @@
       "note": "Backward compat: uses material-based TYPOLOGY_CAPS (Figure 1 values, not adopted by City)"
     },
     {
-      "condition": "standard in CARBON_TARGETS (LEED, Passive House, CaGBC, etc.)",
-      "output": "CARBON_TARGETS[standard]",
-      "note": "Fixed caps: LEED BD+C v4.1 = 500, LEED 40% = 300, ZCB = 250, PH = 200, CaGBC = 175"
+      "condition": "standard == 'BR18 (Denmark)'",
+      "output": "500",
+      "note": "Danish Building Regulations 2018 limit"
+    },
+    {
+      "condition": "standard == 'IPCC AR6 EPC'",
+      "output": "3.39",
+      "note": "IPCC AR6 Equal Per Capita pathway"
+    },
+    {
+      "condition": "standard == 'IPCC AR6 EA'",
+      "output": "0.17",
+      "note": "IPCC AR6 Equal Allocation pathway"
+    },
+    {
+      "condition": "standard == 'CaGBC ZCB D'",
+      "output": "425",
+      "note": "Canada Green Building Council Zero Carbon Building Design standard"
+    },
+    {
+      "condition": "standard == 'CaGBC ZCB P'",
+      "output": "425",
+      "note": "Canada Green Building Council Zero Carbon Building Performance standard"
+    },
+    {
+      "condition": "standard == 'LEED BD+C v4.1'",
+      "output": "500"
+    },
+    {
+      "condition": "standard == 'LEED BD+C v4.1 (40%)'",
+      "output": "300"
+    },
+    {
+      "condition": "standard == 'Zero Carbon Building'",
+      "output": "250"
+    },
+    {
+      "condition": "standard == 'Passive House'",
+      "output": "200"
+    },
+    {
+      "condition": "standard == 'CaGBC Zero Carbon'",
+      "output": "175"
     },
     {
       "condition": "standard == 'Self Reported'",
@@ -153,6 +193,11 @@
         "Pt.3 Office": 600
       },
       "CARBON_TARGETS": {
+        "BR18 (Denmark)": 500,
+        "IPCC AR6 EPC": 3.39,
+        "IPCC AR6 EA": 0.17,
+        "CaGBC ZCB D": 425,
+        "CaGBC ZCB P": 425,
         "LEED BD+C v4.1": 500,
         "LEED BD+C v4.1 (40%)": 300,
         "Zero Carbon Building": 250,
@@ -259,11 +304,74 @@
       "expected": "N/A"
     },
     {
+      "name": "BR18 (Denmark)",
+      "inputs": {
+        "building.carbonStandard": "BR18 (Denmark)"
+      },
+      "expected": 500
+    },
+    {
+      "name": "IPCC AR6 EPC",
+      "inputs": {
+        "building.carbonStandard": "IPCC AR6 EPC"
+      },
+      "expected": 3.39
+    },
+    {
+      "name": "IPCC AR6 EA",
+      "inputs": {
+        "building.carbonStandard": "IPCC AR6 EA"
+      },
+      "expected": 0.17
+    },
+    {
+      "name": "CaGBC ZCB D",
+      "inputs": {
+        "building.carbonStandard": "CaGBC ZCB D"
+      },
+      "expected": 425
+    },
+    {
+      "name": "CaGBC ZCB P",
+      "inputs": {
+        "building.carbonStandard": "CaGBC ZCB P"
+      },
+      "expected": 425
+    },
+    {
       "name": "LEED BD+C v4.1",
       "inputs": {
         "building.carbonStandard": "LEED BD+C v4.1"
       },
       "expected": 500
+    },
+    {
+      "name": "LEED BD+C v4.1 (40%)",
+      "inputs": {
+        "building.carbonStandard": "LEED BD+C v4.1 (40%)"
+      },
+      "expected": 300
+    },
+    {
+      "name": "Zero Carbon Building",
+      "inputs": {
+        "building.carbonStandard": "Zero Carbon Building"
+      },
+      "expected": 250
+    },
+    {
+      "name": "Passive House",
+      "inputs": {
+        "building.carbonStandard": "Passive House"
+      },
+      "expected": 200
+    },
+    {
+      "name": "CaGBC Zero Carbon",
+      "inputs": {
+        "building.carbonStandard": "CaGBC Zero Carbon"
+      },
+      "expected": 175
     }
   ],
   "references": [

--- a/docs/parnas-tables/emissions/tgs4-building-category.json
+++ b/docs/parnas-tables/emissions/tgs4-building-category.json
@@ -1,0 +1,163 @@
+{
+  "id": "emissions.tgs4.buildingCategory",
+  "label": "TGS4 Building Category",
+  "section": "S02",
+  "classification": "C",
+  "_meta": {
+    "description": "Maps Major Occupancy and storey count to TGS4 building category. The Ontario Building Code Part 9 applies to residential buildings of 3 storeys or fewer; Part 3 applies to all other buildings. Within Part 3, residential and commercial occupancies have different embodied carbon caps than other occupancy types.",
+    "source": "City of Toronto, Toronto Green Standard Version 4",
+    "authority": "Ryan Zizzo, Mantle Climate (co-author of TGS4 guidelines with Kelly Alvarez-Doran)"
+  },
+  "signature": {
+    "inputs": [
+      {
+        "name": "building.majorOccupancy",
+        "type": "string",
+        "description": "OBC Major Occupancy classification (d_12)"
+      },
+      {
+        "name": "building.numStoreys",
+        "type": "number",
+        "description": "Number of storeys above grade (d_16_storeys)"
+      }
+    ],
+    "output": {
+      "type": "string",
+      "enum": [
+        "Part 9 Low-Rise Residential",
+        "Part 3 Residential/Commercial",
+        "Part 3 Other"
+      ]
+    }
+  },
+  "domain": {
+    "preconditions": [
+      {
+        "condition": "building.majorOccupancy in ['A-Assembly', 'B1-Detention', 'B2-Care and Treatment', 'B3-Detention Care & Treatment', 'C-Residential', 'D-Business & Personal Services', 'E-Mercantile', 'F-Industrial']",
+        "description": "Must be a valid OBC Major Occupancy"
+      },
+      {
+        "condition": "building.numStoreys >= 1",
+        "description": "At least one storey"
+      }
+    ],
+    "invariants": [
+      {
+        "condition": "output is one of the three TGS4 categories",
+        "description": "Every valid input maps to exactly one category"
+      },
+      {
+        "condition": "non-residential occupancies always map to Part 3",
+        "description": "Part 9 applies only to C-Residential"
+      }
+    ]
+  },
+  "behavior": [
+    {
+      "condition": "occupancy == 'C-Residential' AND storeys <= 3",
+      "output": "Part 9 Low-Rise Residential",
+      "note": "OBC Part 9: residential, ≤3 storeys. LCA scope A1-A3."
+    },
+    {
+      "condition": "occupancy == 'C-Residential' AND storeys > 3",
+      "output": "Part 3 Residential/Commercial",
+      "note": "OBC Part 3: mid-to-high rise residential. LCA scope A1-A5."
+    },
+    {
+      "condition": "occupancy == 'D-Business & Personal Services'",
+      "output": "Part 3 Residential/Commercial",
+      "note": "Commercial office. LCA scope A1-A5."
+    },
+    {
+      "condition": "occupancy == 'E-Mercantile'",
+      "output": "Part 3 Residential/Commercial",
+      "note": "Commercial retail. LCA scope A1-A5."
+    },
+    {
+      "condition": "occupancy in ['A-Assembly', 'B1-Detention', 'B2-Care and Treatment', 'B3-Detention Care & Treatment', 'F-Industrial']",
+      "output": "Part 3 Other",
+      "note": "All other OBC occupancy types. LCA scope A1-A5."
+    }
+  ],
+  "edgeCases": [
+    {
+      "condition": "occupancy is null or unrecognized",
+      "handling": "Default to 'Part 3 Other'",
+      "rationale": "Most conservative category (highest caps)"
+    },
+    {
+      "condition": "storeys is null or unparseable",
+      "handling": "Default to 2 storeys",
+      "rationale": "Default building.numStoreys value; puts residential in Part 9"
+    }
+  ],
+  "formula": {
+    "implementation": "BuildingInfoNodes.js: getTGS4Category()"
+  },
+  "tests": [
+    {
+      "name": "Low-rise residential (2 storeys)",
+      "inputs": { "building.majorOccupancy": "C-Residential", "building.numStoreys": 2 },
+      "expected": "Part 9 Low-Rise Residential"
+    },
+    {
+      "name": "Low-rise residential (3 storeys — boundary)",
+      "inputs": { "building.majorOccupancy": "C-Residential", "building.numStoreys": 3 },
+      "expected": "Part 9 Low-Rise Residential"
+    },
+    {
+      "name": "Mid-rise residential (4 storeys — boundary)",
+      "inputs": { "building.majorOccupancy": "C-Residential", "building.numStoreys": 4 },
+      "expected": "Part 3 Residential/Commercial"
+    },
+    {
+      "name": "High-rise residential (12 storeys)",
+      "inputs": { "building.majorOccupancy": "C-Residential", "building.numStoreys": 12 },
+      "expected": "Part 3 Residential/Commercial"
+    },
+    {
+      "name": "Commercial office",
+      "inputs": { "building.majorOccupancy": "D-Business & Personal Services", "building.numStoreys": 5 },
+      "expected": "Part 3 Residential/Commercial"
+    },
+    {
+      "name": "Commercial retail",
+      "inputs": { "building.majorOccupancy": "E-Mercantile", "building.numStoreys": 1 },
+      "expected": "Part 3 Residential/Commercial"
+    },
+    {
+      "name": "Assembly",
+      "inputs": { "building.majorOccupancy": "A-Assembly", "building.numStoreys": 2 },
+      "expected": "Part 3 Other"
+    },
+    {
+      "name": "Care facility",
+      "inputs": { "building.majorOccupancy": "B2-Care and Treatment", "building.numStoreys": 3 },
+      "expected": "Part 3 Other"
+    },
+    {
+      "name": "Industrial",
+      "inputs": { "building.majorOccupancy": "F-Industrial", "building.numStoreys": 1 },
+      "expected": "Part 3 Other"
+    },
+    {
+      "name": "Single storey residential",
+      "inputs": { "building.majorOccupancy": "C-Residential", "building.numStoreys": 1 },
+      "expected": "Part 9 Low-Rise Residential"
+    }
+  ],
+  "references": [
+    {
+      "source": "City of Toronto TGS Version 4 — Part 9 Low-Rise Residential",
+      "url": "https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/low-rise-residential-version-4/buildings-energy-emissions/"
+    },
+    {
+      "source": "City of Toronto TGS Version 4 — Part 3 Mid-to-High Rise",
+      "url": "https://www.toronto.ca/city-government/planning-development/official-plan-guidelines/toronto-green-standard/toronto-green-standard-version-4/mid-to-high-rise-residential-non-residential-version-4/buildings-energy-emissions-resilience/"
+    },
+    {
+      "source": "Ontario Building Code — Part 9 vs Part 3 applicability",
+      "note": "Part 9 applies to buildings ≤3 storeys and ≤600 m² per floor; Part 3 applies to all others"
+    }
+  ]
+}

--- a/src/sections/Section01.js
+++ b/src/sections/Section01.js
@@ -447,11 +447,23 @@ window.TEUI.SectionModules.sect01 = (function () {
       else if (d_15 === "IPCC AR6 EA") {
         m_6_result = 4.07;
       }
-      // IF(D15="TGS4",((I$41/I39)),"N/A")
+      // TGS4 Tier 2/3: i_41 / d_16 (modelled embodied carbon vs adopted cap)
+      else if (d_15 === "TGS4 Tier 2" || d_15 === "TGS4 Tier 3") {
+        const d_16 = window.TEUI?.parseNumeric?.(
+          window.TEUI?.StateManager?.getValue("d_16"), 0
+        ) ?? 0;
+        if (d_16 > 0) {
+          m_6_result = i_41 / d_16;
+          m_6_result = Math.round(m_6_result * 100) / 100;
+        } else {
+          m_6_result = "N/A";
+        }
+      }
+      // TGS4 "Typical Values": backward compat, i_41 / i_39
       else if (d_15 === "TGS4") {
         if (i_39 > 0) {
           m_6_result = i_41 / i_39;
-          m_6_result = Math.round(m_6_result * 100) / 100; // Round to 2 decimal places
+          m_6_result = Math.round(m_6_result * 100) / 100;
         } else {
           m_6_result = "N/A";
         }

--- a/src/sections/Section02.js
+++ b/src/sections/Section02.js
@@ -272,6 +272,8 @@ window.TEUI.SectionModules.sect02 = (function () {
             { value: "IPCC AR6 EPC", name: "IPCC AR6 EPC" },
             { value: "IPCC AR6 EA", name: "IPCC AR6 EA" },
             { value: "TGS4", name: "Typical Values" },
+            { value: "TGS4 Tier 2", name: "TGS4 Tier 2" },
+            { value: "TGS4 Tier 3", name: "TGS4 Tier 3" },
             { value: "CaGBC ZCB D", name: "CaGBC ZCB D" },
             { value: "CaGBC ZCB P", name: "CaGBC ZCB P" },
             { value: "Self Reported", name: "Self Reported" },
@@ -749,38 +751,33 @@ window.TEUI.SectionModules.sect02 = (function () {
         return;
       }
 
+      // TGS4 Tier 2/3: adopted caps by occupancy category
+      if (carbonStandard === "TGS4 Tier 2" || carbonStandard === "TGS4 Tier 3") {
+        const occupancy = ReferenceState.getValue("d_12") || "A-Assembly";
+        const storeys = parseFloat(getModeAwareGlobalValue("d_16_storeys") || "2") || 2;
+        const category = window.TEUI.ComputationNodes.BuildingInfo.getTGS4Category(occupancy, storeys);
+        const cap = window.TEUI.ComputationNodes.BuildingInfo.TGS4_CAPS[category]?.[carbonStandard];
+        setFieldValue("d_16", cap ?? "N/A", "calculated");
+        storeReferenceResults();
+        return;
+      }
+
+      // TGS4 "Typical Values": backward compat, uses material-based typology
       if (carbonStandard === "TGS4") {
         const tgs4Value =
           window.TEUI?.parseNumeric?.(getModeAwareGlobalValue("i_39"), 0) ?? 0;
         setFieldValue("d_16", tgs4Value, "calculated");
+        storeReferenceResults();
         return;
       }
 
-      const AR6_EPC_K5 = 3.39;
-      const AR6_EA_L5 = 0.17;
-
+      // Fixed standard targets from CARBON_TARGETS
+      const fixedTarget = window.TEUI.ComputationNodes.BuildingInfo.CARBON_TARGETS[carbonStandard];
       let targetValue;
-      switch (carbonStandard) {
-        case "BR18 (Denmark)":
-          targetValue = 500;
-          break;
-        case "IPCC AR6 EPC":
-          targetValue = AR6_EPC_K5;
-          break;
-        case "IPCC AR6 EA":
-          targetValue = AR6_EA_L5;
-          break;
-        case "CaGBC ZCB D":
-          targetValue = 425;
-          break;
-        case "CaGBC ZCB P":
-          targetValue = 425;
-          break;
-        case "Self Reported":
-          targetValue = modelledValueI41;
-          break;
-        default:
-          targetValue = modelledValueI41;
+      if (fixedTarget !== null && fixedTarget !== undefined) {
+        targetValue = fixedTarget;
+      } else {
+        targetValue = modelledValueI41;
       }
       setFieldValue("d_16", targetValue, "calculated");
 
@@ -852,6 +849,17 @@ window.TEUI.SectionModules.sect02 = (function () {
         return;
       }
 
+      // TGS4 Tier 2/3: adopted caps by occupancy category
+      if (carbonStandard === "TGS4 Tier 2" || carbonStandard === "TGS4 Tier 3") {
+        const occupancy = TargetState.getValue("d_12") || "A-Assembly";
+        const storeys = parseFloat(getModeAwareGlobalValue("d_16_storeys") || "2") || 2;
+        const category = window.TEUI.ComputationNodes.BuildingInfo.getTGS4Category(occupancy, storeys);
+        const cap = window.TEUI.ComputationNodes.BuildingInfo.TGS4_CAPS[category]?.[carbonStandard];
+        setFieldValue("d_16", cap ?? "N/A", "calculated");
+        return;
+      }
+
+      // TGS4 "Typical Values": backward compat, uses material-based typology
       if (carbonStandard === "TGS4") {
         const tgs4Value =
           window.TEUI?.parseNumeric?.(getModeAwareGlobalValue("i_39"), 0) ?? 0;
@@ -859,34 +867,14 @@ window.TEUI.SectionModules.sect02 = (function () {
         return;
       }
 
-      const AR6_EPC_K5 = 3.39;
-      const AR6_EA_L5 = 0.17;
-
+      // Fixed standard targets from CARBON_TARGETS
+      const fixedTarget = window.TEUI.ComputationNodes.BuildingInfo.CARBON_TARGETS[carbonStandard];
       let targetValue;
-      switch (carbonStandard) {
-        case "BR18 (Denmark)":
-          targetValue = 500;
-          break;
-        case "IPCC AR6 EPC":
-          targetValue = AR6_EPC_K5;
-          break;
-        case "IPCC AR6 EA":
-          targetValue = AR6_EA_L5;
-          break;
-        case "CaGBC ZCB D":
-          targetValue = 425;
-          break;
-        case "CaGBC ZCB P":
-          targetValue = 425;
-          break;
-        case "Self Reported":
-          targetValue = modelledValueI41;
-          break;
-        default:
-          targetValue = modelledValueI41;
+      if (fixedTarget !== null && fixedTarget !== undefined) {
+        targetValue = fixedTarget;
+      } else {
+        targetValue = modelledValueI41;
       }
-
-      // Since mode is 'target', this will update `target_d_16` AND the global `d_16` for the DOM.
       setFieldValue("d_16", targetValue, "calculated");
     } catch (error) {
       console.error("[Section02] Error in Target Model calculations:", error);

--- a/src/sections/Section05.js
+++ b/src/sections/Section05.js
@@ -1381,30 +1381,28 @@ window.TEUI.SectionModules.sect05 = (function () {
         const d_15_value = window.TEUI.StateManager.getValue(fieldId);
         let d_16_value;
 
-        // Excel formula logic: =IF(D15="BR18 (Denmark)",500,IF(D15="IPCC AR6 EPC"...
-        switch (d_15_value) {
-          case "BR18 (Denmark)":
-          case "TGS4":
-            d_16_value = 500;
-            break;
-          case "CaGBC ZCB D":
-          case "CaGBC ZCB P":
-            d_16_value = 425;
-            break;
-          case "IPCC AR6 EPC":
-            // TODO: Look up from S3-Carbon-Standards K7 when available
-            d_16_value = 400; // Placeholder
-            break;
-          case "IPCC AR6 EA":
-            // TODO: Look up from S3-Carbon-Standards L7 when available
-            d_16_value = 450; // Placeholder
-            break;
-          case "Self Reported":
-            // Use current i_41 value from S05
+        // TGS4 Tier 2/3: adopted caps by occupancy category
+        if (d_15_value === "TGS4 Tier 2" || d_15_value === "TGS4 Tier 3") {
+          const occField = isReference ? "ref_d_12" : "d_12";
+          const storField = isReference ? "ref_d_16_storeys" : "d_16_storeys";
+          const occupancy = window.TEUI.StateManager.getValue(occField) || "A-Assembly";
+          const storeys = parseFloat(window.TEUI.StateManager.getValue(storField) || "2") || 2;
+          const category = window.TEUI.ComputationNodes.BuildingInfo.getTGS4Category(occupancy, storeys);
+          const cap = window.TEUI.ComputationNodes.BuildingInfo.TGS4_CAPS[category]?.[d_15_value];
+          d_16_value = cap ?? "N/A";
+        } else if (d_15_value === "TGS4") {
+          // "Typical Values": backward compat, let Section02 handle via i_39 typology path
+          return;
+        } else {
+          // All other standards: use CARBON_TARGETS lookup
+          const fixedTarget = window.TEUI.ComputationNodes.BuildingInfo.CARBON_TARGETS[d_15_value];
+          if (fixedTarget !== null && fixedTarget !== undefined) {
+            d_16_value = fixedTarget;
+          } else if (d_15_value === "Self Reported") {
             d_16_value = getSectionValue("i_41", isReference);
-            break;
-          default:
+          } else {
             d_16_value = "N/A";
+          }
         }
 
         // Update S02's d_16 field

--- a/src/sections/nodes/BuildingInfoNodes.js
+++ b/src/sections/nodes/BuildingInfoNodes.js
@@ -21,12 +21,42 @@
   // Carbon targets by standard (kgCO2e/m²)
   const CARBON_TARGETS = {
     "Self Reported": null,
+    "BR18 (Denmark)": 500,
+    "IPCC AR6 EPC": 3.39,
+    "IPCC AR6 EA": 0.17,
+    "CaGBC ZCB D": 425,
+    "CaGBC ZCB P": 425,
     "LEED BD+C v4.1": 500,
     "LEED BD+C v4.1 (40%)": 300,
     "Zero Carbon Building": 250,
     "Passive House": 200,
     "CaGBC Zero Carbon": 175,
   };
+
+  // TGS4 Adopted Embodied Carbon Caps (kgCO2e/m²)
+  // Source: City of Toronto TGS Version 4 (adopted values, not Figure 1)
+  // Caps do NOT vary by material type — Ryan Zizzo, Mantle Climate
+  const TGS4_CAPS = {
+    "Part 9 Low-Rise Residential": { "TGS4 Tier 2": 250, "TGS4 Tier 3": null },
+    "Part 3 Residential/Commercial": { "TGS4 Tier 2": 350, "TGS4 Tier 3": 250 },
+    "Part 3 Other": { "TGS4 Tier 2": 400, "TGS4 Tier 3": 275 },
+  };
+
+  /**
+   * Maps Major Occupancy + storey count to TGS4 building category.
+   * Part 9: residential ≤3 storeys (OBC threshold).
+   * Part 3: everything else.
+   * See: docs/parnas-tables/emissions/tgs4-building-category.json
+   */
+  function getTGS4Category(occupancy, storeys) {
+    if (occupancy === "C-Residential") {
+      return storeys <= 3 ? "Part 9 Low-Rise Residential" : "Part 3 Residential/Commercial";
+    }
+    if (occupancy === "D-Business & Personal Services" || occupancy === "E-Mercantile") {
+      return "Part 3 Residential/Commercial";
+    }
+    return "Part 3 Other";
+  }
 
   /**
    * Register all Building Info nodes with the computation graph
@@ -162,7 +192,7 @@
     });
 
     // Embodied Carbon Target (based on carbon standard selection)
-    // Uses i_39 (typology) for TGS4, i_41 (user modelled) for Self Reported
+    // See: docs/parnas-tables/emissions/embodied-carbon-target.json
     graph.registerNode({
       id: "building.embodiedCarbonTarget",
       legacyId: "d_16",
@@ -171,7 +201,9 @@
       dependencies: [
         "building.carbonStandard",
         "building.typologyEmbodiedCarbon",
-        "building.userModelledEmbodiedCarbon"
+        "building.userModelledEmbodiedCarbon",
+        "building.majorOccupancy",
+        "building.numStoreys"
       ],
       label: "Embodied Carbon Target (kgCO2e/m²)",
       compute: (inputs) => {
@@ -179,17 +211,25 @@
         const typologyValue = parseFloat(inputs["building.typologyEmbodiedCarbon"]) || 0;
         const userModelledValue = parseFloat(inputs["building.userModelledEmbodiedCarbon"]) || 345.82;
 
-        // Not Reported returns N/A
         if (standard === "Not Reported") {
           return "N/A";
         }
 
-        // TGS4 uses typology value (i_39)
+        // TGS4 Tier 2/3: adopted caps by occupancy category
+        if (standard === "TGS4 Tier 2" || standard === "TGS4 Tier 3") {
+          const occupancy = inputs["building.majorOccupancy"] || "A-Assembly";
+          const storeys = parseFloat(inputs["building.numStoreys"]) || 2;
+          const category = getTGS4Category(occupancy, storeys);
+          const cap = TGS4_CAPS[category]?.[standard];
+          return cap ?? "N/A";
+        }
+
+        // TGS4 "Typical Values": backward compat, uses material-based typology
         if (standard === "TGS4") {
           return typologyValue;
         }
 
-        // Check for fixed standard targets
+        // Fixed standard targets (BR18, IPCC, CaGBC, LEED, etc.)
         const target = CARBON_TARGETS[standard];
         if (target !== null && target !== undefined) {
           return target;
@@ -254,6 +294,8 @@
   window.TEUI.ComputationNodes.BuildingInfo = {
     register,
     CARBON_TARGETS,
+    TGS4_CAPS,
+    getTGS4Category,
   };
 
   console.log("[BuildingInfoNodes] Module loaded");

--- a/src/sections/nodes/KeyValuesNodes.js
+++ b/src/sections/nodes/KeyValuesNodes.js
@@ -402,6 +402,7 @@
         "building.serviceLife",
         "building.carbonStandard",
         "building.typologyEmbodiedCarbon",
+        "building.embodiedCarbonTarget",
         "keyValues.actual.annualCarbon",
         "keyValues.target.annualCarbon",
         "keyValues.useType",
@@ -437,8 +438,16 @@
         } else if (d_15 === "IPCC AR6 EA") {
           const result = 4.07;
           return `${Math.round(result * 100)}%`;
+        } else if (d_15 === "TGS4 Tier 2" || d_15 === "TGS4 Tier 3") {
+          // TGS4 Tier 2/3: i_41 / d_16 (modelled embodied carbon vs adopted cap)
+          const d_16 = parseNum(inputs["building.embodiedCarbonTarget"]);
+          if (d_16 > 0) {
+            const result = i_41 / d_16;
+            return `${Math.round(result * 100)}%`;
+          }
+          return "N/A";
         } else if (d_15 === "TGS4") {
-          // TGS4: i_41 / i_39
+          // TGS4 "Typical Values": backward compat, i_41 / i_39
           if (i_39 > 0) {
             const result = i_41 / i_39;
             return `${Math.round(result * 100)}%`;


### PR DESCRIPTION
## Summary
- Implements #110
- Add "TGS4 Tier 2" and "TGS4 Tier 3" as new Carbon Benchmarking Standard options using the City of Toronto's adopted embodied carbon caps (not Figure 1 typical values)
- Caps vary by building category (Part 9 Low-Rise Residential, Part 3 Residential/Commercial, Part 3 Other) and tier, not by material type
- Keep existing "TGS4" option as "Typical Values" for backward compatibility
- Add Parnas table specifications for all 13 carbon benchmarking standards and TGS4 building category determination

## TGS4 Adopted Caps

| Category | Tier 2 | Tier 3 |
|---|---|---|
| Part 9 Low-Rise Residential (A1-A3) | 250 | N/A |
| Part 3 Residential/Commercial (A1-A5) | 350 | 250 |
| Part 3 Other (A1-A5) | 400 | 275 |

## Files changed
- `BuildingInfoNodes.js` — `TGS4_CAPS` lookup table, `getTGS4Category()`, updated `building.embodiedCarbonTarget` node
- `Section02.js` — dropdown options, `calculateReferenceModel()` and `calculateTargetModel()` 
- `Section05.js` — `updateCarbonTarget` listener
- `KeyValuesNodes.js` — m_6 lifetime carbon percentage for tier standards
- `Section01.js` — legacy m_6 calculation

## Test plan
- [x] All 20 Playwright tests pass
- [x] TGS4 Tier 2 + C-Residential + 2 storeys → d_16 = 250
- [x] TGS4 Tier 2 + C-Residential + 4 storeys → d_16 = 350
- [x] TGS4 Tier 3 + C-Residential + 2 storeys → d_16 = N/A
- [x] TGS4 Tier 3 + A-Assembly → d_16 = 275
- [x] Existing "TGS4" typical values option still works unchanged
- [x] Non-TGS4 standards unchanged