### PR TITLE
Restore S11 moisture risk indicators (🌵/💧) via graph + DOMBridge

### DIFF
--- a/src/core/ui/DOMBridge.js
+++ b/src/core/ui/DOMBridge.js
@@ -104,6 +104,11 @@
     n_85: "raw", n_86: "raw", n_87: "raw", n_88: "raw",
     n_89: "raw", n_90: "raw", n_91: "raw", n_92: "raw",
     n_93: "raw", n_94: "raw", n_95: "raw", n_97: "raw",
+    // S11 Envelope: surface temperatures with condensation risk emoji
+    o_85: "condensation", o_86: "condensation", o_87: "condensation",
+    o_88: "condensation", o_89: "condensation", o_90: "condensation",
+    o_91: "condensation", o_92: "condensation", o_93: "condensation",
+    o_94: "condensation", o_95: "condensation",
 
     // S08 Humidity guidance
     k_59: "raw",
@@ -152,6 +157,12 @@
 
   // Tier field → value field mapping (set data-tier attribute)
   const TIER_MAP = { e_10: "f_10", h_10: "i_10" };
+
+  // S11 surface temperature → condensation risk companion node (cr_ fields)
+  const CONDENSATION_FIELDS = [
+    "o_85", "o_86", "o_87", "o_88", "o_89",
+    "o_90", "o_91", "o_92", "o_93", "o_94", "o_95"
+  ];
 
   // ==========================================================================
   // STAMP ALL
@@ -215,6 +226,9 @@
 
       const formatType = FORMAT[legacyId] || "number-2dp-comma";
 
+      // Condensation fields handled by stampCondensationIndicators
+      if (formatType === "condensation") continue;
+
       if (formatType === "raw") {
         el.textContent = String(value);
         stamped++;
@@ -239,6 +253,9 @@
 
     // Stamp Section01 data attributes (tier badges, status indicators)
     stampSection01Attributes(state, targetModelId, legacyToSemantic, parse);
+
+    // Stamp S11 condensation risk indicators (🌵/💧 + surface temp)
+    stampCondensationIndicators(state, refModelId || targetModelId, legacyToSemantic, parse, fmt);
 
     console.log(`[DOMBridge] Stamped ${stamped} values`);
   }
@@ -269,6 +286,39 @@
         const n = parse(text, 0);
         el.dataset.status = n <= 100 ? "pass" : "fail";
       }
+    }
+  }
+
+  /**
+   * Stamp S11 condensation risk indicators.
+   * Graph computes cr_85-cr_95 ("risk"/"safe"/""); bridge renders 💧/🌵 + temp.
+   */
+  function stampCondensationIndicators(state, modelId, lookup, parse, fmt) {
+    for (const oField of CONDENSATION_FIELDS) {
+      const el = document.querySelector(`[data-field-id="${oField}"]`);
+      if (!el) continue;
+
+      const tempPath = lookup.get(oField);
+      if (!tempPath) continue;
+      const tempValue = state.getValueForModel(modelId, tempPath);
+
+      // No assembly (area = 0) → empty cell
+      if (tempValue === "" || tempValue === undefined || tempValue === null) {
+        el.textContent = "";
+        continue;
+      }
+
+      const temp = parse(tempValue, NaN);
+      if (isNaN(temp)) { el.textContent = ""; continue; }
+
+      // Read companion condensation risk node (cr_ field)
+      const crField = "cr_" + oField.slice(2); // o_85 → cr_85
+      const riskPath = lookup.get(crField);
+      const risk = riskPath ? state.getValueForModel(modelId, riskPath) : "";
+
+      const emoji = risk === "risk" ? "\uD83D\uDCA7" : risk === "safe" ? "\uD83C\uDF35" : "";
+      const formatted = fmt(temp, "number-2dp-comma");
+      el.textContent = emoji ? emoji + " " + formatted : formatted;
     }
   }
 

--- a/src/sections/Section11.js
+++ b/src/sections/Section11.js
@@ -2041,7 +2041,7 @@ window.TEUI.SectionModules.sect11 = (function () {
     console.log("[S11] ✅ S10 area listeners registered for both modes");
   }
 
-  // Condensation risk helpers removed — graph computes surface temperatures
+  // Legacy helpers removed — graph computes surface temperatures + condensation risk (cr_85-cr_95)
   // calculateComponentRow, calculateThermalBridgePenalty removed — graph computes
   // getFieldFormat, updateReferenceIndicators removed — graph handles indicators
   // calculateReferenceModel, calculateTargetModel removed — graph computes

--- a/src/sections/nodes/TransmissionLossNodes.js
+++ b/src/sections/nodes/TransmissionLossNodes.js
@@ -782,6 +782,33 @@
       });
     });
 
+    // ========================================================================
+    // CONDENSATION RISK INDICATORS (rows 85-95)
+    // Passivhaus threshold: risk when T_surface < T_interior - 4.2°C
+    // Returns "risk" or "safe"; DOMBridge renders 💧 or 🌵
+    // ========================================================================
+    const RISK_THRESHOLD = 4.2;
+
+    ALL_COMPONENTS.forEach(({ row, id, label }) => {
+      graph.registerNode({
+        id: `transmissionLoss.${id}.condensationRisk`,
+        legacyId: `cr_${row}`,
+        section: "S11",
+        classification: "C",
+        dependencies: [
+          `transmissionLoss.${id}.surfaceTemp`,
+          "climate.heating.setpoint"
+        ],
+        label: `${label} Condensation Risk`,
+        compute: (inputs) => {
+          const surfaceTemp = inputs[`transmissionLoss.${id}.surfaceTemp`];
+          if (surfaceTemp === "" || surfaceTemp === null || surfaceTemp === undefined) return "";
+          const tInterior = parseNum(inputs["climate.heating.setpoint"], 21);
+          return parseNum(surfaceTemp) < (tInterior - RISK_THRESHOLD) ? "risk" : "safe";
+        }
+      });
+    });
+
     console.log("[TransmissionLossNodes] Registered", inputs.length, "inputs");
   }
 


### PR DESCRIPTION
The condensation risk emojis were removed during the Pattern A strip (0f7f45e).
The surface temperature calculations survived in the graph, but the threshold
check and emoji rendering were lost.

- TransmissionLossNodes: add cr_85-cr_95 condensation risk nodes that compare
  surface temp against Passivhaus threshold (T_interior - 4.2°C)
- DOMBridge: add stampCondensationIndicators() that reads the companion cr_
  value and renders 💧 (risk) or 🌵 (safe) prefixed to the formatted temperature
- Mark o_85-o_95 as "condensation" format so the dedicated stamper handles them

https://claude.ai/code/session_01Pw9nNwyCaQQEa41KhjaM34