### PR TITLE
Fix compliance checkmark/X colors in sections 08, 09, and 11

### DIFF
--- a/src/core/ui/DOMBridge.js
+++ b/src/core/ui/DOMBridge.js
@@ -231,6 +231,14 @@
 
       if (formatType === "raw") {
         el.textContent = String(value);
+        // Apply checkmark/warning classes for compliance status indicators
+        if (value === "✓") {
+          el.classList.remove("warning");
+          el.classList.add("checkmark");
+        } else if (value === "✗") {
+          el.classList.remove("checkmark");
+          el.classList.add("warning");
+        }
         stamped++;
         continue;
       }


### PR DESCRIPTION
DOMBridge.stampAll() was setting ✓/✗ text content for compliance status
fields but not applying CSS classes, causing them to render in default
black. Now applies 'checkmark' (green) class for ✓ and 'warning' (red)
class for ✗ when stamping raw compliance values.

Fixes: S09/S11 checkmarks and X's showing black instead of green/red,
and S08 X marks showing green instead of red (stale initial class).

https://claude.ai/code/session_015Bi7GmhCEmgoz7CwA7ocp9